### PR TITLE
Missing semicolon in variable definitions in the default template

### DIFF
--- a/bin/commands/create.js
+++ b/bin/commands/create.js
@@ -26,7 +26,7 @@ var create = module.exports = function create(name) {
           
           var template = [
             'var flatiron = require(\'flatiron\'),',
-            ' path = require(\'path\')',
+            ' path = require(\'path\'),',
             ' app = flatiron.app;',
             '',
             'app.use(flatiron.plugins.cli, {',


### PR DESCRIPTION
I think you're missing a semicolon here :)
