### PR TITLE
[fix] cli plugin throws errors for broken command modules

### DIFF
--- a/lib/flatiron/plugins/cli.js
+++ b/lib/flatiron/plugins/cli.js
@@ -63,7 +63,11 @@ exports.attach = function (options) {
         needle = require(path.join(options.dir, parts.shift()));
       }
       catch (e) {
-        // ignore, try for usage
+        if (!e.message.match(/^Cannot find module/)) {
+          throw e;
+        }
+
+        // No module; Go for the usage.
       }
       while (needle) {
         if (needle.usage) {

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
     "pkginfo": "0.2.x"
   },
   "main": "./lib/flatiron",
+  "bin": {
+    "flatiron": "./bin/flatiron"
+  },
   "engines": { "node": ">= 0.4.0" }
 }


### PR DESCRIPTION
If the error is a "Module not found", the existing behavior of showing "usage" persists. However, if the error doesn't match against a "Module not found" message, the error is thrown.

I noticed that flatiron throws some sort of "enhanced" error object, so I don't know if this is supposed to be handled elsewhere or what.
