### PR TITLE
Check that error message includes the filename we required(). 

### DIFF
--- a/lib/flatiron/plugins/cli.js
+++ b/lib/flatiron/plugins/cli.js
@@ -144,7 +144,9 @@ exports.commands = function (options) {
         return true;
       }
       catch (err) {
-        if (!err.message.match(/^Cannot find module/)) {
+        // If that file could not be found, error message should start with
+        // "Cannot find module" and contain the name of the file we tried requiring.
+        if (!err.message.match(/^Cannot find module/) || err.message.indexOf(name) === -1) {
           throw err;
         }
 


### PR DESCRIPTION
I had this problem when experimenting with command files. Suddenly, my command would stop working, and I would just get the usage test whenever trying to run it.

The root cause was an error in another module I had required, but the error message was being squelched by Flatiron.

This adds a check that the error message actually contains the command name. This will reduce the chance of false positives (but not completely eliminate it).
