### PR TITLE
Pass the app object to commands as context.

### DIFF
--- a/lib/flatiron/plugins/cli.js
+++ b/lib/flatiron/plugins/cli.js
@@ -230,7 +230,7 @@ exports.commands = function (options) {
             parts.push(null);
           }
           
-          command.apply(this, parts.concat(callback));
+          command.apply(app, parts.concat(callback));
           return;
         }
         


### PR DESCRIPTION
This makes it possible for commands residing in their own file to access app.argv amongst other things.
