### PR TITLE
flatiron.plugins.http: Don't `res.emit('next')` if `app.http.onError` is defined

### DIFF
--- a/lib/flatiron/plugins/http.js
+++ b/lib/flatiron/plugins/http.js
@@ -70,7 +70,7 @@ exports.attach = function (options) {
       after: app.http.after,
       before: app.http.before.concat(function (req, res) {
         if (!app.router.dispatch(req, res, app.http.onError || union.errorHandler)) {
-          res.emit('next');
+          if (!app.http.onError) res.emit('next');
         }
       }),
       headers: app.http.headers,


### PR DESCRIPTION
`flatiron.plugins.http` allows you to pass in an onError function. If you choose to pass this function in, however, it gets overridden by `res.emit('next')` (which ends up using union's error handler). It should work the same way if you don't use onError, but if you choose to use it, it allows you to do things like custom 404 and server error pages. Without this change, it's not that straightforward using this plugin (or possible?).
