### PR TITLE
[fix] || instead of && when trying to handle deep aliases

### DIFF
--- a/lib/flatiron/plugins/cli.js
+++ b/lib/flatiron/plugins/cli.js
@@ -241,7 +241,7 @@ exports.commands = function (options) {
         usage;
 
     if (app.cli.source || app.commands[name]) {    
-      if (!app.commands[name] && !loadCommand(name, parts[0])) {
+      if (!app.commands[name] || !loadCommand(name, parts[0])) {
         return callback();
       }
       


### PR DESCRIPTION
This makes it so that `jitsu users confirm` in the flatiron branch will work again.
