### PR TITLE
[fix] Fix version command in flatiron

### DIFF
--- a/bin/flatiron
+++ b/bin/flatiron
@@ -8,7 +8,10 @@ var actions = {
   create: 'Creates an empty template for a flatiron application'
 };
 
+app.version = flatiron.version;
+
 app.use(flatiron.plugins.cli, {
+  version: true,
   dir: path.join(__dirname, '..', 'lib', 'flatiron', 'cli'),
   usage: [
     'flatiron',


### PR DESCRIPTION
On master

```
➤ flatiron -v
help:   flatiron
help:   
help:   Commands:
help:     create - Creates an empty template for a flatiron application
```

After this fix

```
➤ flatiron -v
0.1.16
```
