### PR TITLE
Fix trailing whitespace, change scaffolding format of the create command

### DIFF
--- a/lib/flatiron/cli/create.js
+++ b/lib/flatiron/cli/create.js
@@ -2,9 +2,6 @@ var fs = require('fs'),
     path = require('path'),
     flatiron = require('../../flatiron'),
     common = flatiron.common,
-    async = common.async,
-    directories = common.directories,
-    cpr = common.cpr,
     app = flatiron.app;
 
 module.exports = function create(name, type, callback) {
@@ -12,37 +9,39 @@ module.exports = function create(name, type, callback) {
   type = type || 'http';
 
   var root = path.join(process.cwd(), name),
-      scaffold = path.join(__dirname, '..', '..', '..', 'scaffolds', type);
+      scaffold = path.join(__dirname, '..', '..', '..', 'scaffolds', type),
+      create = JSON.parse(fs.readFileSync(path.join(scaffold, 'create.json'), 'utf8')),
+      files = create.files,
+      dirs = create.dirs;
 
   //
   // Creates directories specified in `/scaffolds/:type/directories.json`.
   //
   function createDirs(next) {
-    var dirs = directories.normalize(root,
-      JSON.parse(fs.readFileSync(path.join(scaffold, 'directories.json'), 'utf8'))
-    );
-
-    Object.keys(dirs).forEach(function (name) {
-      app.log.info('Creating directory ' + name.grey);
+    dirs.forEach(function (dir) {
+      app.log.info('Creating directory ' + dir.grey);
     });
 
-    directories.create(dirs, next);
+    function createDir(dir, nextDir) {
+      common.mkdirp(path.join(root, dir), 0755, nextDir);
+    }
+
+    common.async.forEachSeries(dirs, createDir, next);
   }
 
   //
   // Creates files specified in `/scaffolds/:type/files.json`.
   //
   function createFiles(next) {
-    var files = directories.normalize(root,
-      JSON.parse(fs.readFileSync(path.join(scaffold, 'files.json'), 'utf8'))
-    );
+    files.forEach(function (file) {
+      app.log.info('Writing file ' + file.grey);
+    });
 
     function copyFile(file, nextFile) {
-      app.log.info('Writing file ' + file.grey);
-      cpr(path.join(scaffold, file), files[file], nextFile);
+      common.cpr(path.join(scaffold, file), path.join(root, file), nextFile);
     }
 
-    async.mapSeries(Object.keys(files), copyFile, next);
+    common.async.forEachSeries(files, copyFile, next);
   }
 
   //
@@ -60,7 +59,7 @@ module.exports = function create(name, type, callback) {
 
   app.log.info('Creating application ' + name.magenta)
   app.log.info('Using ' + type.yellow + ' scaffold.');
-  async.series([
+  common.async.series([
     createDirs,
     createPackage,
     createFiles

--- a/scaffolds/cli/create.json
+++ b/scaffolds/cli/create.json
@@ -1,0 +1,13 @@
+{
+  "dirs": [
+    "config",
+    "lib",
+    "lib/commands",
+    "test"
+  ],
+  "files": [
+    "app.js",
+    "config/config.json",
+    "lib/index.js"
+  ]
+}

--- a/scaffolds/cli/directories.json
+++ b/scaffolds/cli/directories.json
@@ -1,6 +1,0 @@
-{
-  "config": "#ROOT/config",
-  "lib": "#ROOT/lib",
-  "commands": "#ROOT/lib/commands",
-  "test": "#ROOT/test"
-}

--- a/scaffolds/cli/files.json
+++ b/scaffolds/cli/files.json
@@ -1,5 +1,0 @@
-{
-  "app.js": "#ROOT/app.js",
-  "config/config.json": "#ROOT/config/config.json",
-  "lib/index.js": "#ROOT/lib/index.js"
-}

--- a/scaffolds/http/create.json
+++ b/scaffolds/http/create.json
@@ -1,0 +1,11 @@
+{
+  "dirs": [
+    "config",
+    "lib",
+    "test"
+  ],
+  "files": [
+    "app.js",
+    "config/config.json"
+  ]
+}

--- a/scaffolds/http/directories.json
+++ b/scaffolds/http/directories.json
@@ -1,5 +1,0 @@
-{
-  "config": "#ROOT/config",
-  "lib": "#ROOT/lib",
-  "test": "#ROOT/test"
-}

--- a/scaffolds/http/files.json
+++ b/scaffolds/http/files.json
@@ -1,4 +1,0 @@
-{
-  "app.js": "#ROOT/app.js",
-  "config/config.json": "#ROOT/config/config.json"
-}


### PR DESCRIPTION
**Quotes from discussion below to summarize PR. --Josh**

> This pull request changes the format of directories.json and files.json into a single create.json inorder to reduce redundancy.
> 
> In the old format, directories.json has to have a key dirname with value #ROOT/dirname for every directory it intends to create.
> 
> From here, https://github.com/flatiron/broadway/blob/master/lib/broadway/common/directories.js#L72, we can say that it is a bit redundant and we can instead save only dirname and add #ROOT ahead of it while creating directory.
> 
> If we didn't change the format, in the future this directories.json might end up looking like this
> 
> https://github.com/flatiron/flatiron/blob/88c99ecfc5bdcf67e6e6227abeccb42648b0d7c4/scaffolds/http/directories.json
> # 44 has been divided into two different prs. One pr is for allowing files to no longer be a special case. Another is this pr.
> 
> This pr also consolidates the var statments and uses a new commit to fix whitespace issues and doesn't move the create functions to a seperate namespace.
