### PR TITLE
default director parseBody option to false for flatiron plugin

### DIFF
--- a/lib/flatiron/plugins/http.js
+++ b/lib/flatiron/plugins/http.js
@@ -46,7 +46,8 @@ exports.attach = function (options) {
   };
 
   app.router = new director.http.Router().configure({
-    async: true
+    async: true,
+    parseBody: false
   });
 
   app.start = function (port, host, callback) {


### PR DESCRIPTION
master version of director parses the body of an incoming request, and so does union, if the `parseBody` option is not set to false, flatiron will end up parsing the body twice during a post.  This pull requests sets the parseBody configuration flag so that this will not happen.

see

[https://github.com/flatiron/director/pull/54](https://github.com/flatiron/director/pull/54)
