### PR TITLE
Fixed bug in http.plugin where the mixin was trying to mixin itself.

### DIFF
--- a/lib/flatiron/plugins/http.js
+++ b/lib/flatiron/plugins/http.js
@@ -37,7 +37,7 @@ exports.attach = function (options) {
   //
   // Define the `http` namespace on the app for later use
   //
-  app.http = flatiron.common.mixin({}, app.http, options || {});
+  app.http = flatiron.common.mixin({}, app, options || {});
 
   app.http.before = app.http.before || [];
   app.http.after = app.http.after || [];


### PR DESCRIPTION
```
app.http = flatiron.common.mixin({}, app.http, options || {});
```

```
app.http = flatiron.common.mixin({}, app, options || {});
```
