### PR TITLE
Set cli.notFoundUsage to false to not show `Cannot find module ...`

### DIFF
--- a/lib/flatiron/plugins/cli.js
+++ b/lib/flatiron/plugins/cli.js
@@ -40,6 +40,10 @@ exports.attach = function (options) {
 
   app.cli = common.mixin({}, app.cli, options);
 
+  if (app.cli.notFoundUsage == undefined) {
+    app.cli.notFoundUsage = true;
+  }
+
   //
   // Setup `this.argv` to use `optimist`.
   //
@@ -193,9 +197,11 @@ exports.commands = function (options) {
           app.cli.sourceDir = stats.isDirectory();
         }
         catch (ex) {
-          showUsage(app.usage || [
-            'Cannot find commands for ' + name.magenta
-          ]);
+          if (app.cli.notFoundUsage) {
+            showUsage(app.usage || [
+              'Cannot find commands for ' + name.magenta
+            ]);
+          }
 
           return false;
         }
@@ -218,9 +224,11 @@ exports.commands = function (options) {
         }
 
         if (!silent) {
-          showUsage(app.usage || [
-            'Cannot find commands for ' + name.magenta
-          ]);
+          if (app.cli.notFoundUsage) {
+            showUsage(app.usage || [
+              'Cannot find commands for ' + name.magenta
+            ]);
+          }
         }
 
         return false;


### PR DESCRIPTION
I needed this thing for a small flatiron cli app I was writing.
