### PR TITLE
Some modifications to resourceful plugin

### DIFF
--- a/examples/resourceful-app/app/resources/creature.js
+++ b/examples/resourceful-app/app/resources/creature.js
@@ -1,6 +1,6 @@
-var resourceful = require('resourceful');
+var app = require('../../../../lib/flatiron').app;
 
-var Creature = module.exports = resourceful.define('creature', function () {
+app.r.define('creature', function () {
   this.string('diet');
   this.bool('vertebrate');
   this.array('belly');

--- a/lib/flatiron/plugins/resourceful.js
+++ b/lib/flatiron/plugins/resourceful.js
@@ -7,9 +7,7 @@
  */
 
 var path = require('path'),
-    fs = require('fs'),
     flatiron = require('../../flatiron'),
-    common = flatiron.common,
     resourceful;
 
 try {
@@ -36,9 +34,18 @@ exports.attach = function (options) {
   options = options || {};
 
   //
-  // Create `app.resources` if it does not exist already.
+  // Create `app.r` if it does not exist already.
+  // Initialize it with some resourceful helpers
   //
-  app.resources = app.resources || {};
+  app.r = app.r || {
+    define: function (name, definition) {
+      if ((typeof name === 'function' || typeof name === 'object') && !definition) {
+        definition = name;
+        name = definition.name;
+      }
+      app.r[flatiron.common.capitalize(name)] = resourceful.define(name, definition);
+    }
+  };
 
   //
   // Lazy-load the resources directory based on a few intelligent defaults:
@@ -48,26 +55,15 @@ exports.attach = function (options) {
   // * `app.root`: Relative root to the resources directory ('/app/resources')
   //
   if (options.dir || options.root || app.root) {
-    app._resourceDir = options.dir 
+    app._resourceDir = options.dir
       || path.join(options.root || app.root, 'app', 'resources');
 
-    common.tryReaddirSync(app._resourceDir).forEach(function (file) {
+    flatiron.common.tryReaddirSync(app._resourceDir).forEach(function (file) {
       file = file.replace('.js', '');
-
-      app.resources.__defineGetter__(common.capitalize(file), function () {
-        delete app.resources[file];
-        return app.resources[file] = require(
-          path.resolve(app._resourceDir, file)
-        );
-      });
+      require(path.resolve(app._resourceDir, file));
     });
   }
-  
-  //
-  // Expose a couple of resourceful helpers
-  //
-  app.define = resourceful.define;
-  
+
   //
   // TODO: Determine how best to integrate `restful` here.
   //
@@ -76,25 +72,25 @@ exports.attach = function (options) {
 exports.init = function (done) {
   var app = this,
       options;
-      
+
   //
   // Attempt to merge defaults passed to `app.use(flatiron.plugins.resourceful)`
   // with any additional configuration that may have been loaded.
   //
-  options = common.mixin(
-    {}, 
+  options = flatiron.common.mixin(
+    {},
     app.options['resourceful'],
     app.config.get('resourceful') || {}
   );
-  
+
   app.config.set('resourceful', options);
-  
+
   //
   // Remark: Should we accept the autoMigrate option?
   //
   if (options.engine) {
     resourceful.use(options.engine, options);
-  } 
-  
+  }
+
   done();
 };


### PR DESCRIPTION
@indexzero This was my code originally, I had to go offline before pushing it.

With the current code, a user needs to type `app.resources.Creature` everytime he wants to use that model. After this pr, he needs to type `app.r.Creature`.

`app.r` for loaded resources
`app.v` for loaded views
`app.p` for loaded presenters

All the above initialized in `rvp` template along with `http` plugin
