### PR TITLE
[minor] Create the HTTP server before calling app.init

### DIFF
--- a/lib/flatiron/plugins/http.js
+++ b/lib/flatiron/plugins/http.js
@@ -57,6 +57,8 @@ exports.attach = function (options) {
       host = null;
     }
 
+    app.createServer();
+
     app.init(function (err) {
       if (err) {
         if (callback) {
@@ -90,7 +92,7 @@ exports.attach = function (options) {
       host = null;
     }
 
-    app.createServer();
+    if (!app.server) app.createServer();
 
     return host
       ? app.server.listen(port, host, callback)


### PR DESCRIPTION
This allows plugins to attach it to the HTTP server during the broadway plugin's `init` stage. A practical example of this would be a socket.io plugin. Or anything else that can only be attached directly on a http server instance.
