### PR TITLE
Added ability to pass in 'buffer' option to Union when creating via http plugin

### DIFF
--- a/lib/flatiron/plugins/http.js
+++ b/lib/flatiron/plugins/http.js
@@ -43,6 +43,7 @@ exports.attach = function (options) {
 
   app.http.route = flatiron.common.mixin({ async: true }, app.http.route || {});
 
+  app.http.buffer = (app.http.buffer !== false);
   app.http.before = app.http.before || [];
   app.http.after = app.http.after || [];
   app.http.headers = app.http.headers || {
@@ -74,6 +75,7 @@ exports.attach = function (options) {
 
   app.createServer = function(){
     app.server = union.createServer({
+      buffer: app.http.buffer,
       after: app.http.after,
       before: app.http.before.concat(function (req, res) {
         if (!app.router.dispatch(req, res, app.http.onError || union.errorHandler)) {


### PR DESCRIPTION
This allows you to use formidable to enable file uploads, since formidable needs "buffer: false" when creating Union.
