### PR TITLE
lib/flatiron.js: Replace deprecated __defineGetter/__defineSetter__

### DIFF
--- a/lib/flatiron.js
+++ b/lib/flatiron.js
@@ -37,25 +37,31 @@ flatiron.plugins = broadway.common.mixin(
   broadway.common.requireDirLazy(path.join(__dirname, 'flatiron', 'plugins'))
 );
 
-//
-// ### getter @app {flatiron.App}
-// Gets the default top-level Application for `flatiron`
-//
-flatiron.__defineGetter__('app', function () {
-  if (!_app) {
-    _app = new flatiron.App();
+
+Object.defineProperty(flatiron, 'app', {
+
+  // Don't allow another `.defineProperty` on 'app'
+  configurable: false,
+
+  //
+  // ### getter @app {flatiron.App}
+  // Gets the default top-level Application for `flatiron`
+  //
+  get: function() {
+    return _app = _app || flatiron.createApp();
+  },
+
+  //
+  // #### setter @app {flatiron.App}
+  // Options for the application to create or the application to set
+  //
+  set: function(value) {
+    if (value instanceof flatiron.App) return _app = value;
+    return _app = flatiron.createApp(value);
   }
 
-  return _app;
 });
 
-//
-// ### setter @app {flatiron.App}
-// Sets the default top-level Application for `flatiron`
-//
-flatiron.__defineSetter__('app', function (value) {
-  _app = value;
-});
 
 //
 // ### function createApp (options)


### PR DESCRIPTION
@coderarity and I weren't sure how to document this, and not sure if the set change will be welcomed.

The only difference between the original set/get is that the new set also allows options to be passed, instead of an instance of `flatiron.App`. You can still use an instance of `flatiron.App` for backwards compatibility, so no major API change was implemented.

Feedback welcome, especially on the documentation.
