### PR TITLE
README: Correct order of parameters to app.start().

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ app.use(flatiron.plugins.http, {
 
 You can read more about these options on the [union project page](https://github.com/flatiron/union#readme).
 
-### Start The Server with `app.start(<host>, port, <callback(err)>)`
+### Start The Server with `app.start(port, <host>, <callback(err)>)`
 
 This method will both call `app.init` (which will call any asynchronous initialization steps on loaded plugins) and start the http server with the given arguments. For example, the following will start your flatiron http server on port 8080:
 


### PR DESCRIPTION
Uses (port, host), not (host, port).

Function signature here: https://github.com/flatiron/flatiron/blob/03d77f3508e2aebf97a5d2334f88246fb352e703/lib/flatiron/plugins/http.js#L39
