### PR TITLE
[fix] HTTP plugin start/listen getting callback mixed up.

### DIFF
--- a/lib/flatiron/plugins/http.js
+++ b/lib/flatiron/plugins/http.js
@@ -52,27 +52,6 @@ exports.attach = function (options) {
 
   app.router = new director.http.Router().configure(app.http.route);
 
-  app.start = function (port, host, callback) {
-    if (!callback && typeof host === 'function') {
-      callback = host;
-      host = null;
-    }
-
-    app.createServer();
-
-    app.init(function (err) {
-      if (err) {
-        if (callback) {
-          return callback(err);
-        }
-
-        throw err;
-      }
-
-      app.listen(port, host, callback);
-    });
-  };
-
   app.createServer = function(){
     app.server = union.createServer({
       buffer: app.http.buffer,
@@ -88,16 +67,27 @@ exports.attach = function (options) {
     });
   };
 
-  app.listen = function (port, host, callback) {
-    if (!callback && typeof host === 'function') {
-      callback = host;
-      host = null;
-    }
-
+  app.listen = function (/*port, host, callback*/) {
     if (!app.server) app.createServer();
 
-    return host
-      ? app.server.listen(port, host, callback)
-      : app.server.listen(port, callback);
+    return app.server.listen.apply(app.server, arguments);
+  };
+
+  app.start = function (/*port, host, callback*/) {
+    var args = flatiron.common.args(arguments);
+
+    app.createServer();
+
+    app.init(function (err) {
+      if (err) {
+        if (args.callback) {
+          return args.callback(err);
+        }
+
+        throw err;
+      }
+
+      app.listen.apply(app, [].concat(args, args.callback));
+    });
   };
 };


### PR DESCRIPTION
If no port is provided, the callback is left in the `port` field. This causes the listen callback to be ignored.
