### PR TITLE
[fix] Handle the user cancelling creation of a scaffold.

### DIFF
--- a/lib/flatiron/cli/create.js
+++ b/lib/flatiron/cli/create.js
@@ -81,7 +81,14 @@ module.exports = function create(name, type, callback) {
     createDirs,
     createPackage,
     createFiles
-  ], function onComplete(next) {
+  ], function onComplete(err) {
+      if (err) {
+        if (err.message === 'canceled') {
+          // Start a new line to make the cancel look pretty.
+          return process.stdout.write('\n');
+        }
+        throw err;
+      }
       app.log.info('Application ' + info.name.magenta + ' is now ready');
       callback();
     }


### PR DESCRIPTION
This will keep error messages from appearing when `^C` is hit during async prompting.
