### PR TITLE
Only require files that end in .js (avoid errors from requiring source map files, for example)

### DIFF
--- a/lib/flatiron/plugins/resourceful.js
+++ b/lib/flatiron/plugins/resourceful.js
@@ -83,13 +83,15 @@ exports.attach = function (options) {
     }
 
     files.forEach(function (file) {
-      file = file.replace('.js', '');
-      app.resources.__defineGetter__(common.capitalize(file), function () {
-        delete app.resources[common.capitalize(file)];
-        return app.resources[common.capitalize(file)] = require(
-          path.resolve(app._resourceDir, file)
-        );
-      });
+      if(/\.js$/.test(file)) {
+        file = file.replace('.js', '');
+        app.resources.__defineGetter__(common.capitalize(file), function () {
+          delete app.resources[common.capitalize(file)];
+          return app.resources[common.capitalize(file)] = require(
+            path.resolve(app._resourceDir, file)
+          );
+        });
+      };
     });
 
   }


### PR DESCRIPTION
The resourceful plugin should only attempt to require files ending in .js, to avoid requiring source map files.
