### PR TITLE
[fix] Fix a crash when command directory isn't found

### DIFF
--- a/lib/flatiron/plugins/cli.js
+++ b/lib/flatiron/plugins/cli.js
@@ -198,7 +198,9 @@ exports.commands = function (options) {
         catch (ex) {
           if (app.cli.notFoundUsage) {
             showUsage(app.usage || [
-              'Cannot find commands for ' + name.magenta
+              name
+                ? 'Cannot find commands for ' + name.magenta
+                : 'Cannot find commands'
             ]);
           }
 


### PR DESCRIPTION
Trying to run an empty command with `flatiron.plugins.cli` when the
commands directory wasn't there resulted in the following crash:

```
$ bin/bender-cli

/Users/maciej/dev/js/flatiron/lib/flatiron/plugins/cli.js:201
              'Cannot find commands for ' + name.magenta
                                                ^
TypeError: Cannot read property 'magenta' of undefined
    at loadCommand (/Users/maciej/dev/js/flatiron/lib/flatiron/plugins/cli.js:201:49)
    at executeCommand (/Users/maciej/dev/js/flatiron/lib/flatiron/plugins/cli.js:278:26)
    at Object.app.router.notfound (/Users/maciej/dev/js/flatiron/lib/flatiron/plugins/cli.js:357:5)
    at Router.dispatch (/Users/maciej/dev/js/flatiron/node_modules/director/lib/director/cli.js:50:21)
    at /Users/maciej/dev/js/flatiron/lib/flatiron/plugins/cli.js:87:18
    at onComplete (/Users/maciej/dev/js/flatiron/node_modules/broadway/lib/broadway/app.js:85:5)
    at Object.exports.ensure (/Users/maciej/dev/js/flatiron/node_modules/broadway/lib/broadway/features/index.js:10:10)
    at ensureFeatures (/Users/maciej/dev/js/flatiron/node_modules/broadway/lib/broadway/app.js:91:18)
    at /Users/maciej/dev/js/flatiron/node_modules/broadway/node_modules/utile/node_modules/async/lib/async.js:116:25
    at /Users/maciej/dev/js/flatiron/node_modules/broadway/node_modules/utile/node_modules/async/lib/async.js:24:16
```
