### PR TITLE
[fix] Fix crash when command is empty and app has no usage

### DIFF
--- a/lib/flatiron/plugins/cli.js
+++ b/lib/flatiron/plugins/cli.js
@@ -184,6 +184,11 @@ exports.commands = function (options) {
   //
   function loadCommand(name, command, silent) {
     var resource = app.commands[name];
+    var usage = app.usage || [
+      name
+        ? 'Cannot find commands for ' + name.magenta
+        : 'Cannot find commands'
+    ];
 
     if (resource && (!command || resource[command])) {
       return true;
@@ -197,11 +202,7 @@ exports.commands = function (options) {
         }
         catch (ex) {
           if (app.cli.notFoundUsage) {
-            showUsage(app.usage || [
-              name
-                ? 'Cannot find commands for ' + name.magenta
-                : 'Cannot find commands'
-            ]);
+            showUsage(usage)
           }
 
           return false;
@@ -226,9 +227,7 @@ exports.commands = function (options) {
 
         if (!silent) {
           if (app.cli.notFoundUsage) {
-            showUsage(app.usage || [
-              'Cannot find commands for ' + name.magenta
-            ]);
+            showUsage(usage);
           }
         }
 


### PR DESCRIPTION
```
$ bin/bender-cli
/Users/maciej/dev/js/flatiron/lib/flatiron/plugins/cli.js:230
              'Cannot find commands for ' + name.magenta
                                                ^
TypeError: Cannot read property 'magenta' of undefined
    at loadCommand (/Users/maciej/dev/js/flatiron/lib/flatiron/plugins/cli.js:230:49)
    at executeCommand (/Users/maciej/dev/js/flatiron/lib/flatiron/plugins/cli.js:280:26)
    at Object.app.router.notfound (/Users/maciej/dev/js/flatiron/lib/flatiron/plugins/cli.js:359:5)
    at Router.dispatch (/Users/maciej/dev/js/flatiron/node_modules/director/lib/director/cli.js:50:21)
    at /Users/maciej/dev/js/flatiron/lib/flatiron/plugins/cli.js:87:18
    at onComplete (/Users/maciej/dev/js/flatiron/node_modules/broadway/lib/broadway/app.js:85:5)
    at Object.exports.ensure (/Users/maciej/dev/js/flatiron/node_modules/broadway/lib/broadway/features/index.js:10:10)
    at ensureFeatures (/Users/maciej/dev/js/flatiron/node_modules/broadway/lib/broadway/app.js:91:18)
    at /Users/maciej/dev/js/flatiron/node_modules/broadway/node_modules/utile/node_modules/async/lib/async.js:116:25
    at /Users/maciej/dev/js/flatiron/node_modules/broadway/node_modules/utile/node_modules/async/lib/async.js:24:16
```
